### PR TITLE
Release 0.3.0

### DIFF
--- a/.luabench
+++ b/.luabench
@@ -1,0 +1,3 @@
+path = 'examples/'
+duration = '3s'
+jit = 'on'

--- a/README.md
+++ b/README.md
@@ -15,14 +15,14 @@
 
 Early proof-of-concept
 
-Latest release: `0.2.0`
+Latest release: `0.3.0`
 
 ## Installation
 
 **Via Tarantool Rocks:**
 
 ```bash
-tt rocks --server https://moonlibs.org install luabench 0.1.1
+tt rocks --server https://moonlibs.org install luabench 0.3.0
 ```
 
 **Manual Download:**
@@ -74,8 +74,8 @@ return M
 ### Command Line Usage
 
 ```bash
-Usage: luabench [-v] [--version] [--bmf] [-j <j>] [--no-preambule]
-       [-d <d>] [-h] [<path>]
+Usage: luabench [-v] [--version] [-t <timeout>] [--bmf] [-j <j>]
+       [--no-preambule] [-d <d>] [-h] [<path>]
 
 Runs lua code benchmarks
 
@@ -85,10 +85,11 @@ Arguments:
 Options:
    -v, --verbose         Increase verbosity
    --version             Prints version
-   --bmf                 Reports benchmark in BMF format
+          -t <timeout>,  global timeout (default: 60)
+   --bmf                 Reports benchmark in BMF format (default: false)
    -j <j>                Ons or Offs jit
    --no-preambule        Hides preambule
-   -d <d>                test duration limit
+   -d <d>                test duration limit (default: 3s)
    -h, --help            Show this help message and exit.
 ```
 
@@ -97,19 +98,20 @@ Options:
 ```bash
 .rocks/bin/luabench -d 100x examples/001_bench.lua
 Tarantool version: Tarantool 3.1.0-0-g96f6d88
-Tarantool build: Darwin-x86_64-Release (dynamic)
-Tarantool build flags:  -fexceptions -funwind-tables -fasynchronous-unwind-tables -fno-common -msse2 -Wformat -Wformat-security -Werror=format-security -fstack-protector-strong -fPIC -fmacro-prefix-map=/tmp/tarantool-20240417-5649-53mktp/tarantool-3.1.0=. -std=c11 -Wall -Wextra -Wno-gnu-alignof-expression -Wno-cast-function-type -O3 -DNDEBUG
-CPU: Apple M2 Pro @ 10
+Tarantool build: Darwin-arm64-RelWithDebInfo (static)
+Tarantool build flags:  -fexceptions -funwind-tables -fasynchronous-unwind-tables -fno-common  -fmacro-prefix-map=/var/folders/8x/1m5v3n6d4mn62g9w_65vvt_r0000gn/T/tarantool_install934702387=. -std=c11 -Wall -Wextra -Wno-gnu-alignof-expression -Wno-cast-function-type -O2 -g -DNDEBUG -ggdb -O2
+CPU: Apple M1 @ 8
 JIT: Disabled
 Duration: 100 iters
+Global timeout: 60
 
 --- SKIP:  001_bench::bench_insert:local-table: no local-table
 
 --- BENCH: 001_bench::bench_insert:rewrite-1000
-     100                50.00 ns/op       20000000 op/s       29 B/op   +2.92KB
+     100                30.00 ns/op       33333333 op/s       29 B/op   +2.92KB
 
 --- BENCH: 001_bench::bench_insert:temporary-space
-     100              1100 ns/op            909091 op/s      126 B/op   +12.34KB
+     100               600.0 ns/op         1666667 op/s      126 B/op   +12.34KB
 
 --- SKIP:  001_bench::bench_sum: no summing for today
 ```
@@ -121,20 +123,21 @@ You may specify `-jon` or `-joff` to enable or disable jit by force
 ```bash
 .rocks/bin/luabench -jon -d 100x examples/001_bench.lua
 Tarantool version: Tarantool 3.1.0-0-g96f6d88
-Tarantool build: Darwin-x86_64-Release (dynamic)
-Tarantool build flags:  -fexceptions -funwind-tables -fasynchronous-unwind-tables -fno-common -msse2 -Wformat -Wformat-security -Werror=format-security -fstack-protector-strong -fPIC -fmacro-prefix-map=/tmp/tarantool-20240417-5649-53mktp/tarantool-3.1.0=. -std=c11 -Wall -Wextra -Wno-gnu-alignof-expression -Wno-cast-function-type -O3 -DNDEBUG
-CPU: Apple M2 Pro @ 10
+Tarantool build: Darwin-arm64-RelWithDebInfo (static)
+Tarantool build flags:  -fexceptions -funwind-tables -fasynchronous-unwind-tables -fno-common  -fmacro-prefix-map=/var/folders/8x/1m5v3n6d4mn62g9w_65vvt_r0000gn/T/tarantool_install934702387=. -std=c11 -Wall -Wextra -Wno-gnu-alignof-expression -Wno-cast-function-type -O2 -g -DNDEBUG -ggdb -O2
+CPU: Apple M1 @ 8
 JIT: Enabled
-JIT: SSE2 SSE3 SSE4.1 fold cse dce fwd dse narrow loop abc sink fuse
+JIT: fold cse dce fwd dse narrow loop abc sink fuse
 Duration: 100 iters
+Global timeout: 60
 
 --- SKIP:  001_bench::bench_insert:local-table: no local-table
 
 --- BENCH: 001_bench::bench_insert:rewrite-1000
-     100             14270 ns/op             70077 op/s       36 B/op   +3.56KB
+     100               380.0 ns/op         2631579 op/s       36 B/op   +3.56KB
 
 --- BENCH: 001_bench::bench_insert:temporary-space
-     100              9340 ns/op            107066 op/s      149 B/op   +14.62KB
+     100              1040 ns/op            961538 op/s      149 B/op   +14.61KB
 
 --- SKIP:  001_bench::bench_sum: no summing for today
 ```
@@ -146,28 +149,64 @@ With flag `--bmf` `luabench` prints out to stdout Benchmark results in Bencher J
 ```bash
 .rocks/bin/luabench --bmf -d 100x examples/001_bench.lua
 Tarantool version: Tarantool 3.1.0-0-g96f6d88
-Tarantool build: Darwin-x86_64-Release (dynamic)
-Tarantool build flags:  -fexceptions -funwind-tables -fasynchronous-unwind-tables -fno-common -msse2 -Wformat -Wformat-security -Werror=format-security -fstack-protector-strong -fPIC -fmacro-prefix-map=/tmp/tarantool-20240417-5649-53mktp/tarantool-3.1.0=. -std=c11 -Wall -Wextra -Wno-gnu-alignof-expression -Wno-cast-function-type -O3 -DNDEBUG
-CPU: Apple M2 Pro @ 10
-JIT: Disabled
+Tarantool build: Darwin-arm64-RelWithDebInfo (static)
+Tarantool build flags:  -fexceptions -funwind-tables -fasynchronous-unwind-tables -fno-common  -fmacro-prefix-map=/var/folders/8x/1m5v3n6d4mn62g9w_65vvt_r0000gn/T/tarantool_install934702387=. -std=c11 -Wall -Wextra -Wno-gnu-alignof-expression -Wno-cast-function-type -O2 -g -DNDEBUG -ggdb -O2
+CPU: Apple M1 @ 8
+JIT: Enabled
+JIT: fold cse dce fwd dse narrow loop abc sink fuse
 Duration: 100 iters
+Global timeout: 60
 
 --- SKIP:  001_bench::bench_insert:local-table: no local-table
 
 --- BENCH: 001_bench::bench_insert:rewrite-1000
-     100                50.00 ns/op       20000000 op/s       29 B/op   +2.92KB
+     100               340.0 ns/op         2941176 op/s       36 B/op   +3.56KB
 
 --- BENCH: 001_bench::bench_insert:temporary-space
-     100              1090 ns/op            917431 op/s      126 B/op   +12.34KB
+     100              1100 ns/op            909091 op/s      149 B/op   +14.61KB
 
 --- SKIP:  001_bench::bench_sum: no summing for today
-{"001_bench::bench_insert:temporary-space":{"latency":{"value":1090},"throughput":{"value":917431},"net_bytes":{"value":126}},"001_bench::bench_insert:rewrite-1000":{"latency":{"value":50},"throughput":{"value":20000000},"net_bytes":{"value":29}}}
+{"001_bench::bench_insert:temporary-space":{"latency":{"values":[],"len":2,"value":5360},"bytes":{"values":[],"len":2,"value":0},"throughput":{"values":[],"len":2,"value":186567},"net_bytes":{"values":[],"len":2,"value":160}},"001_bench::bench_insert:rewrite-1000":{"latency":{"values":[],"len":2,"value":3240},"bytes":{"values":[],"len":2,"value":0},"throughput":{"values":[],"len":2,"value":308641},"net_bytes":{"values":[],"len":2,"value":43}}}
 ```
 
 With [bencher](https://bencher.dev/) you may run luabench as follows:
 
 ```bash
 bencher run --project <PROJECT> --adapter json '.rocks/bin/luabench -d 1000x --bmf examples/001_bench.lua'
+```
+
+Also handy script to catch this `.env` file
+
+```bash
+BENCHER_PROJECT=luabench
+BENCHER_ADAPTER=json
+BENCHER_TESTBED=localhost
+LUABENCH_DURATION=3s
+LUABENCH_USE_BMF=true
+LUABENCH_PATH=examples/001_bench.lua
+```
+
+with following command
+
+```bash
+env $(cat .env | xargs) bencher run '.rocks/bin/luabench'
+```
+
+## Configuration of luabench with .luabench file
+
+Starting with `luabench 0.3.0` it is possible to configurate parameters of `luabench` via `.luabench` file.
+
+```lua
+-- Root path of files with benchmarks (relative path of .luabench file)
+path = 'benchmarks/'
+-- Goal wall-time duration of each benchmark run
+duration = '3s'
+-- Status of jit ('on', 'off' or nothing)
+jit = 'on'
+-- Enables report with bmf (set to true for bencher.dev)
+bmf = false
+-- Global fiber slice timeout for each benchmark.
+timeout = 60
 ```
 
 ## Dependencies

--- a/examples/001_bench.lua
+++ b/examples/001_bench.lua
@@ -49,7 +49,7 @@ function M.bench_insert(b)
 	b:run("temporary-space", function(sb)
 		local temporary = box.space.temporary
 		local replace = temporary.replace
-		local tbl = {}
+		local tbl = table.new(2, 0)
 		for i = 1, sb.N do
 			tbl[1] = i%1000+1
 			tbl[2] = true

--- a/examples/002_seive_bench.lua
+++ b/examples/002_seive_bench.lua
@@ -3,8 +3,8 @@ local lb = require 'luabench'
 local M = {}
 
 local function make_seiver(limit)
+	local flags = table.new(limit, 0)
 	return function(b)
-		local flags = {}
 		for _ = 1, b.N do
 			local count = 0
 			table.clear(flags)

--- a/examples/003_global_timeout_bench.lua
+++ b/examples/003_global_timeout_bench.lua
@@ -1,0 +1,18 @@
+local M = {}
+
+local clock = require 'clock'
+
+function M.bench_global_timeout(b)
+	if b.N == 1 then return end
+	local deadlime = clock.time() + b.T
+	local i = 0
+	while true do
+		i = i + 1
+		if clock.time() > deadlime then
+			b.N = i
+			break
+		end
+	end
+end
+
+return M


### PR DESCRIPTION
* Starting with Tarantool 3.0 fiber.check_slice is called automatically by box.* operations. To allow long-running benchmarks luabench permits specifing --timeout (or LUABENCH_TIMEOUT) with seconds precision. Default is 60 (seconds).
* Added possibility to configurate benchmarks with env variables LUABENCH_TIMEOUT, LUABENCH_DURATION, LUABENCH_JIT, LUABENCH_PATH, LUABENCH_USE_BMF.
* Added lower_value (min) and upper_value (max) for bencher reports.